### PR TITLE
Add rosinstall file for quick setup with vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dependencies_ws/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It's recommended to clone and build these repos in their own repo that is used s
 * [agni_serial_protocol](https://github.com/ubi-agni/agni_serial_protocol) - sensor drivers
 * [agni_robots](https://github.com/ubi-agni/agni_robots) - myrmex robot description files
 
+For automated cloning and building of the dependencies into `./dependencies_ws` run `setup_dependencies.sh` (requires [vcstool](https://github.com/dirk-thomas/vcstool)).
 
 ## Sensor hardware configuration
 

--- a/myrmex2ros.rosinstall
+++ b/myrmex2ros.rosinstall
@@ -1,0 +1,29 @@
+repositories:
+  src/agni_robots:
+    type: git
+    url: git@github.com:ubi-agni/agni_robots.git
+    version: noetic-devel
+  src/agni_serial_protocol:
+    type: git
+    url: git@github.com:ubi-agni/agni_serial_protocol.git
+    version: master
+  src/tactile_filters:
+    type: git
+    url: git@github.com:ubi-agni/tactile_filters.git
+    version: master
+  src/tactile_toolbox:
+    type: git
+    url: git@github.com:ubi-agni/tactile_toolbox.git
+    version: melodic-devel
+  src/urdf:
+    type: git
+    url: git@github.com:ubi-agni/urdf.git
+    version: melodic-devel
+  src/urdfdom:
+    type: git
+    url: git@github.com:ubi-agni/urdfdom.git
+    version: ros-sensor-refactoring
+  src/urdfdom_headers:
+    type: git
+    url: git@github.com:ubi-agni/urdfdom_headers.git
+    version: ros-sensor-refactoring

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -z $ROS_DISTRO ]; then
+    echo "ROS_DISTRO is not set. Please source a ROS setup file."
+    exit 1
+fi
+
+mkdir -p dependencies_ws/src
+cd dependencies_ws
+catkin init
+vcs import . < ../myrmex2ros.rosinstall
+catkin b
+
+echo "run 'source dependencies_ws/devel/setup.bash' to use the dependencies workspace."


### PR DESCRIPTION
The rosinstall file allows cloning and updating the dependency repos with vcs (much quicker) and if you feel especially lazy the setup script even creates and builds a workspace for you. 